### PR TITLE
Build linux and macos/arm64 wheels for py3.9 - 3.13

### DIFF
--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -60,7 +60,7 @@ jobs:
     - name: Build and upload packages
       run: |
         eval "$(conda shell.bash hook)"
-        for VERSION in 3.6 3.7 3.8 3.9 3.10 3.11 3.12; do
+        for VERSION in 3.8 3.9 3.10 3.11 3.12 3.13; do
           conda create -n py$VERSION python=$VERSION
           conda activate py$VERSION
           STATIC_LIBS=1 python setup.py build_ext bdist_wheel

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -28,10 +28,10 @@ jobs:
         path: dist/*.tar.gz
 
   build-wheels-macos:
-    runs-on: macos-13
+    runs-on: macos-latest
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
-      MINICONDA_FILENAME: Miniconda3-latest-MacOSX-x86_64.sh
+      MINICONDA_FILENAME: Miniconda3-latest-MacOSX-arm64.sh
       CC: clang
       CXX: clang++
 
@@ -89,7 +89,7 @@ jobs:
     - name: Build package and upload from docker
       run: |
         docker run --rm -v "${PWD}:/opt/fast-mosestokenizer" \
-          ubuntu:22.04 /bin/bash /opt/fast-mosestokenizer/build-release-linux.sh
+          ubuntu:24.04 /bin/bash /opt/fast-mosestokenizer/build-release-linux.sh
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -43,8 +43,14 @@ jobs:
       run: |
         curl -L -o $MINICONDA_FILENAME "https://repo.continuum.io/miniconda/$MINICONDA_FILENAME"
         bash ${MINICONDA_FILENAME} -b -f -p $HOME/miniconda3
-        echo "::add-path::$HOME/miniconda3/bin"
-        echo "::add-path::$HOME/miniconda3/Scripts"
+        echo "$HOME/miniconda3/bin" >> "$GITHUB_PATH"
+        echo "$HOME/miniconda3/Scripts" >> "$GITHUB_PATH"
+
+    - name: Initialize conda
+      shell: bash
+      run: |
+        echo "Current path:"
+        echo ${PATH}
         conda init
 
     - name: Download and build dependencies

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -60,6 +60,7 @@ jobs:
         conda activate meson
         conda install -y meson
         brew install pcre
+        python -m pip install packaging
         make download-build-static-deps
         conda deactivate
 

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -28,7 +28,7 @@ jobs:
         path: dist/*.tar.gz
 
   build-wheels-macos:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       MINICONDA_FILENAME: Miniconda3-latest-MacOSX-x86_64.sh

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -56,7 +56,7 @@ jobs:
     - name: Download and build dependencies
       run: |
         eval "$(conda shell.bash hook)"
-        conda create -n meson python=3.8
+        conda create -n meson python=3.9
         conda activate meson
         conda install -y meson
         brew install pcre
@@ -66,7 +66,7 @@ jobs:
     - name: Build and upload packages
       run: |
         eval "$(conda shell.bash hook)"
-        for VERSION in 3.8 3.9 3.10 3.11 3.12 3.13; do
+        for VERSION in 3.9 3.10 3.11 3.12 3.13; do
           conda create -n py$VERSION python=$VERSION
           conda activate py$VERSION
           STATIC_LIBS=1 python setup.py build_ext bdist_wheel
@@ -88,7 +88,7 @@ jobs:
     - name: Build package and upload from docker
       run: |
         docker run --rm -v "${PWD}:/opt/fast-mosestokenizer" \
-          ubuntu:16.04 /bin/bash /opt/fast-mosestokenizer/build-release-linux.sh
+          ubuntu:22.04 /bin/bash /opt/fast-mosestokenizer/build-release-linux.sh
 
     - uses: actions/upload-artifact@v4
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,12 +73,12 @@ set(DEP_LIBRARIES ${DEP_LIBRARIES} ${Boost_LIBRARIES})
 
 else()
 
-include_directories(${CMAKE_SOURCE_DIR}/deps/boost_1_73_0)
+include_directories(${CMAKE_SOURCE_DIR}/deps/boost_1_88_0)
 set(
   DEP_LIBRARIES
   ${DEP_LIBRARIES}
-  ${CMAKE_SOURCE_DIR}/deps/boost_1_73_0/stage/lib/libboost_thread.a
-  ${CMAKE_SOURCE_DIR}/deps/boost_1_73_0/stage/lib/libboost_program_options.a
+  ${CMAKE_SOURCE_DIR}/deps/boost_1_88_0/stage/lib/libboost_thread.a
+  ${CMAKE_SOURCE_DIR}/deps/boost_1_88_0/stage/lib/libboost_program_options.a
 )
 
 endif()

--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ download-build-static-deps:
 	cd deps/re2-2020-06-01; CXXFLAGS="-fPIC" make
 
 	@echo "Downloading and building glib2"
-	curl -L -o deps/glib-2.72.4.tar.xz \
-		https://download.gnome.org/sources/glib/2.72/glib-2.72.4.tar.xz
-	tar -C deps -xf deps/glib-2.72.4.tar.xz
+	curl -L -o deps/glib-2.79.3.tar.xz \
+		https://download.gnome.org/sources/glib/2.79/glib-2.79.3.tar.xz
+	tar -C deps -xf deps/glib-2.79.3.tar.xz
 	( \
-		cd deps/glib-2.72.4; \
+		cd deps/glib-2.79.3; \
 		meson build --default-library static; \
 		ninja -C build; \
 	)

--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ download-build-static-deps:
 	cd deps/re2-2020-06-01; CXXFLAGS="-fPIC" make
 
 	@echo "Downloading and building glib2"
-	curl -L -o deps/glib-2.79.3.tar.xz \
-		https://download.gnome.org/sources/glib/2.79/glib-2.79.3.tar.xz
-	tar -C deps -xf deps/glib-2.79.3.tar.xz
+	curl -L -o deps/glib-2.85.0.tar.xz \
+		https://download.gnome.org/sources/glib/2.85/glib-2.85.0.tar.xz
+	tar -C deps -xf deps/glib-2.85.0.tar.xz
 	( \
-		cd deps/glib-2.79.3; \
+		cd deps/glib-2.85.0; \
 		meson build --default-library static; \
 		ninja -C build; \
 	)

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ download-build-static-deps:
 
 	@echo "Downloading and building boost"
 	curl -L -o deps/boost_1_73_0.tar.gz \
-		https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.gz
+		https://archives.boost.io/release/1.73.0/source/boost_1_73_0.tar.gz
 	tar -C deps -xf deps/boost_1_73_0.tar.gz
 	( \
 		cd deps/boost_1_73_0; \

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ download-build-static-deps:
 	tar -C deps -xf deps/glib-2.85.0.tar.xz
 	( \
 		cd deps/glib-2.85.0; \
-		meson build --default-library static; \
-		ninja -C build; \
+		meson setup build --default-library static; \
+		meson compile -C build; \
 	)
 
 	@echo "Downloading and building boost"

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,11 @@ download-build-static-deps:
 	)
 
 	@echo "Downloading and building boost"
-	curl -L -o deps/boost_1_73_0.tar.gz \
-		https://archives.boost.io/release/1.73.0/source/boost_1_73_0.tar.gz
-	tar -C deps -xf deps/boost_1_73_0.tar.gz
+	curl -L -o deps/boost_1_88_0.tar.gz \
+		https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
+	tar -C deps -xf deps/boost_1_88_0.tar.gz
 	( \
-		cd deps/boost_1_73_0; \
+		cd deps/boost_1_88_0; \
 		./bootstrap.sh \
 			--with-libraries=thread,program_options \
 			--without-icu \

--- a/build-release-linux.sh
+++ b/build-release-linux.sh
@@ -22,14 +22,14 @@ export PATH=$HOME/miniconda3/bin:$PATH
 eval "$(conda shell.bash hook)"
 
 # Build dependencies as static libraries
-conda create -n meson -y python=3.6
+conda create -n meson -y python=3.9
 conda activate meson
 conda install -y meson
 make download-build-static-deps
 conda deactivate
 
 # Build and upload packages
-for VERSION in 3.8 3.9 3.10 3.11 3.12 3.13; do
+for VERSION in 3.9 3.10 3.11 3.12 3.13; do
     conda create -n py$VERSION -y python=$VERSION
     conda activate py$VERSION
     STATIC_LIBS=1 python setup.py build_ext bdist_wheel \

--- a/build-release-linux.sh
+++ b/build-release-linux.sh
@@ -29,7 +29,7 @@ make download-build-static-deps
 conda deactivate
 
 # Build and upload packages
-for VERSION in 3.6 3.7 3.8 3.9 3.10 3.11 3.12; do
+for VERSION in 3.8 3.9 3.10 3.11 3.12 3.13; do
     conda create -n py$VERSION -y python=$VERSION
     conda activate py$VERSION
     STATIC_LIBS=1 python setup.py build_ext bdist_wheel \

--- a/build-release-linux.sh
+++ b/build-release-linux.sh
@@ -25,6 +25,7 @@ eval "$(conda shell.bash hook)"
 conda create -n meson -y python=3.9
 conda activate meson
 conda install -y meson
+python -m pip install packaging
 make download-build-static-deps
 conda deactivate
 

--- a/cmake/FindGlib2.cmake
+++ b/cmake/FindGlib2.cmake
@@ -32,6 +32,7 @@ set(
   Glib2_INCLUDE_DIRS
   ${CMAKE_SOURCE_DIR}/deps/glib-2.85.0
   ${CMAKE_SOURCE_DIR}/deps/glib-2.85.0/glib
+  ${CMAKE_SOURCE_DIR}/deps/glib-2.85.0/build
   ${CMAKE_SOURCE_DIR}/deps/glib-2.85.0/build/glib
 )
 set(Glib2_LIBRARIES ${CMAKE_SOURCE_DIR}/deps/glib-2.85.0/build/glib/libglib-2.0.a)

--- a/cmake/FindGlib2.cmake
+++ b/cmake/FindGlib2.cmake
@@ -30,11 +30,11 @@ else()  # BUILD_SHARED_LIBS
 # Search for static library from deps
 set(
   Glib2_INCLUDE_DIRS
-  ${CMAKE_SOURCE_DIR}/deps/glib-2.79.3
-  ${CMAKE_SOURCE_DIR}/deps/glib-2.79.3/glib
-  ${CMAKE_SOURCE_DIR}/deps/glib-2.79.3/build/glib
+  ${CMAKE_SOURCE_DIR}/deps/glib-2.85.0
+  ${CMAKE_SOURCE_DIR}/deps/glib-2.85.0/glib
+  ${CMAKE_SOURCE_DIR}/deps/glib-2.85.0/build/glib
 )
-set(Glib2_LIBRARIES ${CMAKE_SOURCE_DIR}/deps/glib-2.79.3/build/glib/libglib-2.0.a)
+set(Glib2_LIBRARIES ${CMAKE_SOURCE_DIR}/deps/glib-2.85.0/build/glib/libglib-2.0.a)
 add_library(glib-2.0::glib-2.0 STATIC IMPORTED)
 set(Glib2_FOUND ON)
 

--- a/cmake/FindGlib2.cmake
+++ b/cmake/FindGlib2.cmake
@@ -30,11 +30,11 @@ else()  # BUILD_SHARED_LIBS
 # Search for static library from deps
 set(
   Glib2_INCLUDE_DIRS
-  ${CMAKE_SOURCE_DIR}/deps/glib-2.72.4
-  ${CMAKE_SOURCE_DIR}/deps/glib-2.72.4/glib
-  ${CMAKE_SOURCE_DIR}/deps/glib-2.72.4/build/glib
+  ${CMAKE_SOURCE_DIR}/deps/glib-2.79.3
+  ${CMAKE_SOURCE_DIR}/deps/glib-2.79.3/glib
+  ${CMAKE_SOURCE_DIR}/deps/glib-2.79.3/build/glib
 )
-set(Glib2_LIBRARIES ${CMAKE_SOURCE_DIR}/deps/glib-2.72.4/build/glib/libglib-2.0.a)
+set(Glib2_LIBRARIES ${CMAKE_SOURCE_DIR}/deps/glib-2.79.3/build/glib/libglib-2.0.a)
 add_library(glib-2.0::glib-2.0 STATIC IMPORTED)
 set(Glib2_FOUND ON)
 


### PR DESCRIPTION
- Add py3.13 wheels and remove py3.6 - 3.8 wheels
- Build MacOS arm64 wheels instead of intel wheels
- Update static library dependencies
